### PR TITLE
Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ WORKDIR /app
 
 RUN apt-get update && \
   apt-get install -y \
-    pkg-config \
     libssl-dev \
     build-essential \
     && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM rust:1.89-slim
+
+WORKDIR /app
+
+RUN apt-get update && \
+  apt-get install -y \
+    pkg-config \
+    libssl-dev \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY . .


### PR DESCRIPTION
Created a Dockerfile for this project, just so we have a consistent development environment. With that, contributors will be able to use the image to run the project tests in  a way they can't possibly mess with the local installation, just like the following example:

```shell
podman run --rm -it quartz cargo test
```

It also lets us use it as a development environment by mounting a volume:

```shell
podman run --rm -it -v "$(pwd):/app" quartz /bin/bash
```

I am not sure if adding some other utilities such as a neovim installation would be useful, so I just let some minimal deps that are required for the project to run
